### PR TITLE
Fix estimate_gc_kinship.sh

### DIFF
--- a/Slurm/estimate_gc_kinship.sh
+++ b/Slurm/estimate_gc_kinship.sh
@@ -8,7 +8,7 @@
 
 #Example
 anno=anno_jabs_2023-04-30.txt
-geno=geno_jabs_2023-04-30.txt.gz
+geno=geno_jabs_2023-04-30.txt
 pheno=pheno_jabs_2023-04-30.txt
 
 module load singularity


### PR DESCRIPTION
The current script fails, possibly due to 
`geno=geno_jabs_2023-04-30.txt.gz`

I changed it to 
`geno=geno_jabs_2023-04-30.txt`

and it is working on my end. 

I'm opening a pull request to merge the suggested change if you find them okay.